### PR TITLE
Fix the link to React Native for Web

### DIFF
--- a/create-react-app-example/README.md
+++ b/create-react-app-example/README.md
@@ -31,3 +31,5 @@ Now you can import any of the `react-native-web` modules!
 ```ts
 import { View } from 'react-native';
 ```
+
+[rnw]: https://github.com/necolas/react-native-web


### PR DESCRIPTION
Just a tiny link fix in the readme for create-react-app-example.