### PR TITLE
Add expo-sentry row to Web Support table

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -70,6 +70,7 @@ You can also check out [**native.directory**](http://native.directory/) for a li
 | AppLoading                | ⏳     | Incomplete   | [`expo`][expo]                                                 |
 | Logs                      | ⏳     | Incomplete   | [`expo`][expo]                                                 |
 | ErrorRecovery             | ⏳     | Incomplete   | [`expo`][expo]                                                 |
+| Sentry                    | ⏳     | Incomplete   | [`expo-sentry`][expo-sentry]                                   |
 | AR                        | 📱     | Native Only  | [`expo-ar`][expo-ar]                                           |
 | AuthSession               | 📱     | Native Only  | [`expo-auth-session`][expo-auth-session]                       |
 | Brightness                | 📱     | Native Only  | [`expo-brightness`][expo-brightness]                           |
@@ -124,6 +125,7 @@ You can also check out [**native.directory**](http://native.directory/) for a li
 [expo-face-detector]: https://github.com/expo/expo/tree/master/packages/expo-face-detector
 [expo-file-system]: https://github.com/expo/expo/tree/master/packages/expo-file-system
 [expo-google-sign-in]: https://github.com/expo/expo/tree/master/packages/expo-google-sign-in
+[expo-sentry]: https://github.com/expo/sentry-expo
 [expo-analytics-segment]: https://github.com/expo/expo/tree/master/packages/expo-analytics-segment
 [expo-sqlite]: https://github.com/expo/expo/tree/master/packages/expo-sqlite
 [expo-document-picker]: https://github.com/expo/expo/tree/master/packages/expo-document-picker

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -70,7 +70,7 @@ You can also check out [**native.directory**](http://native.directory/) for a li
 | AppLoading                | ⏳     | Incomplete   | [`expo`][expo]                                                 |
 | Logs                      | ⏳     | Incomplete   | [`expo`][expo]                                                 |
 | ErrorRecovery             | ⏳     | Incomplete   | [`expo`][expo]                                                 |
-| Sentry                    | ⏳     | Incomplete   | [`expo-sentry`][expo-sentry]                                   |
+| Sentry                    | ⏳     | Incomplete   | [`sentry-expo`][sentry-expo]                                   |
 | AR                        | 📱     | Native Only  | [`expo-ar`][expo-ar]                                           |
 | AuthSession               | 📱     | Native Only  | [`expo-auth-session`][expo-auth-session]                       |
 | Brightness                | 📱     | Native Only  | [`expo-brightness`][expo-brightness]                           |
@@ -125,7 +125,7 @@ You can also check out [**native.directory**](http://native.directory/) for a li
 [expo-face-detector]: https://github.com/expo/expo/tree/master/packages/expo-face-detector
 [expo-file-system]: https://github.com/expo/expo/tree/master/packages/expo-file-system
 [expo-google-sign-in]: https://github.com/expo/expo/tree/master/packages/expo-google-sign-in
-[expo-sentry]: https://github.com/expo/sentry-expo
+[sentry-expo]: https://github.com/expo/sentry-expo
 [expo-analytics-segment]: https://github.com/expo/expo/tree/master/packages/expo-analytics-segment
 [expo-sqlite]: https://github.com/expo/expo/tree/master/packages/expo-sqlite
 [expo-document-picker]: https://github.com/expo/expo/tree/master/packages/expo-document-picker


### PR DESCRIPTION
Added `expo-sentry` as a row to the web support table with "Incomplete" in the Info column.

Feel free to close if expo-sentry support is not planned for web / Let me know if I can help.

In the meanwhile using `import * as Sentry from '@sentry/browser';`. Don't know if there's a better way to do that import since I don't think that works cross-platform.