### PR TITLE
Add branch row to Web Support table

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -71,6 +71,7 @@ You can also check out [**native.directory**](http://native.directory/) for a li
 | Logs                      | ⏳     | Incomplete   | [`expo`][expo]                                                 |
 | ErrorRecovery             | ⏳     | Incomplete   | [`expo`][expo]                                                 |
 | Sentry                    | ⏳     | Incomplete   | [`sentry-expo`][sentry-expo]                                   |
+| Branch                    | ⏳     | Incomplete   | [`expo`][expo]                                                 |
 | AR                        | 📱     | Native Only  | [`expo-ar`][expo-ar]                                           |
 | AuthSession               | 📱     | Native Only  | [`expo-auth-session`][expo-auth-session]                       |
 | Brightness                | 📱     | Native Only  | [`expo-brightness`][expo-brightness]                           |


### PR DESCRIPTION
Added [branch](https://github.com/expo/expo/blob/master/packages/expo/src/Branch.ts) as a row to the web support table with "Incomplete" in the Info column.

Don't know if it's actually planned -- can change it to "Native Only"