### PR TITLE
add reason-react-native example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ buck-out/
 *.jsbundle
 
 web-build
+reason-react/src/*.bs.js

--- a/reason-react/App.js
+++ b/reason-react/App.js
@@ -1,0 +1,4 @@
+import React from "react";
+const Hello = require("./src/Hello.bs").make;
+
+export default () => <Hello />;

--- a/reason-react/README.md
+++ b/reason-react/README.md
@@ -1,0 +1,7 @@
+# Using Expo for web with Reason React Native
+
+From the [ReasonReact Installation Guide](https://reasonml.github.io/reason-react/docs/en/installation#bucklescript), install BuckleScript.
+
+Install packages including the version of [Reason React Native](https://github.com/reasonml-community/bs-react-native) that supports hooks and interop with react-native APIs.
+
+Run `yarn run re:watch` to build Reason files into JS and (in a separate tab), `expo start --web --non-interactive` to start the webpack server via the Expo CLI.

--- a/reason-react/app.json
+++ b/reason-react/app.json
@@ -1,0 +1,24 @@
+{
+  "expo": {
+    "name": "Expo Web Reason",
+    "slug": "expo-web-reason",
+    "privacy": "public",
+    "sdkVersion": "32.0.0",
+    "platforms": ["ios", "android", "web"],
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "supportsTablet": true
+    }
+  }
+}

--- a/reason-react/babel.config.js
+++ b/reason-react/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/reason-react/bsconfig.json
+++ b/reason-react/bsconfig.json
@@ -1,0 +1,23 @@
+{
+  "name": "expo-web-reason",
+  "reason": {
+    "react-jsx": 3
+  },
+  "sources": {
+    "dir": "src",
+    "subdirs": true
+  },
+  "package-specs": [
+    {
+      "module": "es6",
+      "in-source": true
+    }
+  ],
+  "suffix": ".bs.js",
+  "namespace": true,
+  "bs-dependencies": [
+    "reason-react",
+    "bs-react-native-monorepo/reason-react-native"
+  ],
+  "refmt": 3
+}

--- a/reason-react/package.json
+++ b/reason-react/package.json
@@ -1,0 +1,25 @@
+{
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "eject": "expo eject",
+    "re:build": "bsb -make-world -clean-world",
+    "re:watch": "bsb -make-world -clean-world -w"
+  },
+  "dependencies": {
+    "bs-react-native-monorepo": "https://github.com/reasonml-community/bs-react-native",
+    "expo": "^33.0.0-alpha.web.3",
+    "react": "16.5.0",
+    "react-dom": "^16.8.6",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz",
+    "react-native-web": "0.11.3",
+    "reason-react": "0.7.0"
+  },
+  "devDependencies": {
+    "babel-preset-expo": "^5.0.0",
+    "bs-platform": "^5.0.4"
+  },
+  "private": true
+}

--- a/reason-react/src/Hello.re
+++ b/reason-react/src/Hello.re
@@ -1,0 +1,23 @@
+open ReactNative;
+
+let containerStyle =
+  Style.(
+    style(
+      ~flex=1.,
+      ~backgroundColor="#F5FCFF",
+      ~alignItems=`center,
+      ~justifyContent=`center,
+      (),
+    )
+  );
+
+let welcomeStyle =
+  Style.(style(~fontSize=20., ~textAlign=`center, ~margin=10.->pt, ()));
+
+[@react.component]
+let make = () =>
+  <View style=containerStyle>
+    <Text style=welcomeStyle>
+      {ReasonReact.string("Open up App.js to start working on your app!")}
+    </Text>
+  </View>;


### PR DESCRIPTION
I saw that a typescript example was added recently and thought some folks might want to have a reason-react example as well. This PR uses the latest support for reason-react 0.7.0 (with hooks) via the hooks and `react-jsx3` support using [reason-react-native](https://github.com/reasonml-community/bs-react-native/tree/master/reason-react-native) within bs-react-native.

