### PR TITLE
Correct deployment docs for GH

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,7 +96,7 @@ Add the following to your `package.json`:
 {
     "homepage": "http://evanbacon.github.io/expo-gh-pages",
     "scripts": {
-        "deploy": "gh-pages -d build",
+        "deploy": "gh-pages -d web-build",
         "predeploy": "expo build:web"
     }
 }
@@ -150,7 +150,7 @@ Here are the formal instructions for deploying to GitHub Pages:
    ```js
    "scripts": {
      /* ... */
-     "deploy": "gh-pages -d build",
+     "deploy": "gh-pages -d web-build",
      "predeploy": "expo build:web"
    }
    ```


### PR DESCRIPTION
I noticed that the docs didn't quite work right anymore, just because of a simple mistake with the directory name for one of the npm scripts. This fixes the issue.

## Before

```sh
ryan@penguin:~/workspace/SoYoureConsideringBrownfield$ yarn deploy
yarn run v1.17.3
$ expo build:web
[====================] 100% (16.3 seconds)

Compiled with warnings.

asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  ./fonts/MaterialCommunityIcons.ttf (503 KiB)

webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
$ gh-pages -d build
ENOENT: no such file or directory, stat '/home/ryan/workspace/SoYoureConsideringBrownfield/build'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## After

```sh
ryan@penguin:~/workspace/SoYoureConsideringBrownfield$ yarn deploy
yarn run v1.17.3
$ expo build:web
[====================] 100% (12.7 seconds)

Compiled with warnings.

asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  ./fonts/MaterialCommunityIcons.ttf (503 KiB)

webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
$ gh-pages -d web-build
Published
Done in 21.75s.
```